### PR TITLE
Test sparse checkout with alpha pj-rehearse

### DIFF
--- a/ci-operator/config/openshift/addon-operator/openshift-addon-operator-main.yaml
+++ b/ci-operator/config/openshift/addon-operator/openshift-addon-operator-main.yaml
@@ -45,7 +45,7 @@ releases:
 resources:
   '*':
     limits:
-      memory: 4Gi
+      memory: 4096Mi
     requests:
       cpu: 100m
       memory: 200Mi

--- a/ci-operator/jobs/openshift/addon-operator/openshift-addon-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/addon-operator/openshift-addon-operator-main-presubmits.yaml
@@ -151,7 +151,7 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:sparse-checkout
         imagePullPolicy: Always
         name: ""
         resources:
@@ -217,7 +217,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:sparse-checkout
         imagePullPolicy: Always
         name: ""
         ports:
@@ -286,7 +286,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:sparse-checkout
         imagePullPolicy: Always
         name: ""
         ports:
@@ -355,7 +355,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:sparse-checkout
         imagePullPolicy: Always
         name: ""
         ports:

--- a/ci-operator/jobs/openshift/addon-operator/openshift-addon-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/addon-operator/openshift-addon-operator-main-presubmits.yaml
@@ -129,6 +129,14 @@ presubmits:
     cluster: build06
     context: ci/prow/images
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - build/Dockerfile
+      - build/Dockerfile.webhook
+      - deploy-extras/docker/api-mock.Dockerfile
+      - deploy-extras/docker/Dockerfile.src.ci
+      - bundle.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -182,6 +190,14 @@ presubmits:
     cluster: build06
     context: ci/prow/lint
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - build/Dockerfile
+      - build/Dockerfile.webhook
+      - deploy-extras/docker/api-mock.Dockerfile
+      - deploy-extras/docker/Dockerfile.src.ci
+      - bundle.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -243,6 +259,14 @@ presubmits:
     cluster: build06
     context: ci/prow/precommit-check
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - build/Dockerfile
+      - build/Dockerfile.webhook
+      - deploy-extras/docker/api-mock.Dockerfile
+      - deploy-extras/docker/Dockerfile.src.ci
+      - bundle.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -304,6 +328,14 @@ presubmits:
     cluster: build06
     context: ci/prow/unit
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - build/Dockerfile
+      - build/Dockerfile.webhook
+      - deploy-extras/docker/api-mock.Dockerfile
+      - deploy-extras/docker/Dockerfile.src.ci
+      - bundle.Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/core-services/prow/02_config/_config.yaml
+++ b/core-services/prow/02_config/_config.yaml
@@ -363,10 +363,10 @@ plank:
             memory: 250Mi
       timeout: 8h0m0s
       utility_images:
-        clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260429-8f72e9c5a
-        entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260429-8f72e9c5a
-        initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260429-8f72e9c5a
-        sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260429-8f72e9c5a
+        clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260504-1c1101c14
+        entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260504-1c1101c14
+        initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260504-1c1101c14
+        sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260504-1c1101c14
   - config:
       censoring_options:
         exclude_directories:


### PR DESCRIPTION
## Summary
- Tests sparse checkout integration with alpha pj-rehearse-plugin
- Adds `sparse_checkout_files` to addon-operator images job
- Updates clonerefs utility images

## Test plan
- Verify pj-rehearse-alpha creates rehearsal jobs correctly
- Verify sparse checkout does not leak to release repo ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)